### PR TITLE
Network 2.5 bump

### DIFF
--- a/openssl-streams.cabal
+++ b/openssl-streams.cabal
@@ -1,5 +1,5 @@
 Name:                openssl-streams
-Version:             1.1.0.0
+Version:             1.1.1.0
 License:             BSD3
 License-file:        LICENSE
 Category:            Network, IO-Streams


### PR DESCRIPTION
It builds under network 2.5, but I wasn't able to pass test coverage.

`testsuite: SSL_connect: does not exist (Connection refused)`

I think it was probably specific to my machine though.

```
sanitycheck: [Failed]
ok 
expected: Just ()
 but got: Nothing

         Test Cases  Total
    Passed  0           0
    Failed  1           1
    Total   1           1
```
