### PR TITLE
Allow network-2.8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cabal.sandbox.config
 TAGS
 cabal-dev
 dist/
+dist-newstyle/
 tmp/
 *.tix
 .hpc
@@ -16,3 +17,4 @@ tmp/
 .DS_Store
 **/.DS_Store
 docs/templates/out
+.ghc.environment.*

--- a/openssl-streams.cabal
+++ b/openssl-streams.cabal
@@ -32,7 +32,7 @@ Library
                      bytestring    >= 0.9.2  && <0.11,
                      HsOpenSSL     >= 0.10.3 && <0.12,
                      io-streams    >= 1.0    && <1.6,
-                     network       >= 2.4    && <2.8
+                     network       >= 2.4    && <2.9
 
 
 ------------------------------------------------------------------------------
@@ -50,7 +50,7 @@ Test-suite testsuite
   Build-depends:     base,
                      bytestring,
                      HsOpenSSL,
-                     io-stream,
+                     io-streams,
                      network,
                      -- test deps follow.
                      HUnit                >= 1.2     && <2,


### PR DESCRIPTION
Also fix a typo.

The only silently breaking change in `network-2.8` concerns the `Ord` instance for `PortNumber`, which doesn't seem to be used by `openssl-streams`.