### PR TITLE
Remove AI_ADDRCONFIG flag from getAddrInfo hints

### DIFF
--- a/src/System/IO/Streams/SSL.hs
+++ b/src/System/IO/Streams/SSL.hs
@@ -106,7 +106,7 @@ connect ctx host port = do
 
   where
     hints = N.defaultHints {
-              N.addrFlags      = [N.AI_ADDRCONFIG, N.AI_NUMERICSERV]
+              N.addrFlags      = [N.AI_NUMERICSERV]
             , N.addrSocketType = N.Stream
             }
 
@@ -152,7 +152,7 @@ withConnection ctx host port action = do
         eatException $! N.close sock
 
     hints = N.defaultHints {
-              N.addrFlags      = [N.AI_ADDRCONFIG, N.AI_NUMERICSERV]
+              N.addrFlags      = [N.AI_NUMERICSERV]
             , N.addrSocketType = N.Stream
             }
 


### PR DESCRIPTION
Do not use AI_ADDRCONFIG flag in getAddrInfo hints as it cannot handle '127.0.0.1' on IPv6-only machines.