### PR TITLE
Allow bytestring 0.11

### DIFF
--- a/openssl-streams.cabal
+++ b/openssl-streams.cabal
@@ -27,7 +27,7 @@ Library
   Exposed-modules:   System.IO.Streams.SSL
 
   Build-depends:     base          >= 4      && <5,
-                     bytestring    >= 0.9.2  && <0.11,
+                     bytestring    >= 0.9.2  && <0.12,
                      HsOpenSSL     >= 0.10.3 && <0.12,
                      io-streams    >= 1.0    && <1.6,
                      network       >= 2.4    && <3.2


### PR DESCRIPTION
It builds on GHC 9.2.1 which has bytestring 0.11.

The test suite doesn't pass, but it doesn't pass on master either, so this PR can still be merged.

This is preventing Servant from working on GHC 9.2:

```
[__4] trying: servant-http-streams-0.18.4 (user goal)
[__5] trying: http-streams-0.8.9.6 (dependency of servant-http-streams)
[__6] next goal: openssl-streams (dependency of http-streams)
[__6] rejecting: openssl-streams-1.2.3.0 (conflict:
bytestring==0.11.1.0/installed-0.11.1.0, openssl-streams => bytestring>=0.9.2
&& <0.11)
```
