### PR TITLE
Use https for source repo url

### DIFF
--- a/openssl-streams.cabal
+++ b/openssl-streams.cabal
@@ -59,4 +59,4 @@ Test-suite testsuite
 
 source-repository head
   type:     git
-  location: git://github.com/snapframework/openssl-streams.git
+  location: https://github.com/snapframework/openssl-streams.git


### PR DESCRIPTION
GitHub no longer supports the `git://` protocol.